### PR TITLE
Tweak text for shallow clone warning

### DIFF
--- a/Library/Homebrew/cmd/update.sh
+++ b/Library/Homebrew/cmd/update.sh
@@ -406,8 +406,7 @@ This restriction has been made on GitHub's request because updating shallow
 clones is an extremely expensive operation due to the tree layout and traffic of
 Homebrew/homebrew-core and Homebrew/homebrew-cask. We don't do this for you
 automatically to avoid repeatedly performing an expensive unshallow operation in
-CI systems (which should instead be fixed to not use shallow clones). Sorry for
-the inconvenience!
+CI systems (which should use shallow clones). Sorry for the inconvenience!
 EOS
   fi
 


### PR DESCRIPTION
I think the current statement is incorrect and should be not use *un* shallow clones.

Perhaps avoiding the double-negative will make the error message clearer?

(It is quite possible that I'm wrong here, but the error message did thoroughly confuse me 😕 )
